### PR TITLE
photos: implemented Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,27 @@ func uploadAPhoto() {
 	fmt.Printf("Uploaded photo: %#v\n", photo)
 }
 ```
+
+* Update a photo
+```go
+func updatePhoto() {
+	client, err := px500.NewOAuth1ClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	photo, err := client.UpdatePhoto(&px500.UpdateRequest{
+		PhotoID: "211020335",
+		Content: &px500.Photo{
+			Title:  "Updated in tests",
+			Tags:   []string{"tests", "api-client", "golang"},
+			Camera: "iphone 6",
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated photo: %#v\n", photo)
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -196,3 +196,24 @@ func Example_oAuth1TokenFromEnv() {
 		fmt.Printf("err: %v\n", err)
 	}
 }
+
+func Example_client_UpdatePhoto() {
+	client, err := px500.NewOAuth1ClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	photo, err := client.UpdatePhoto(&px500.UpdateRequest{
+		PhotoID: "211020335",
+		Content: &px500.Photo{
+			Title:  "Updated in tests",
+			Tags:   []string{"tests", "api-client", "golang"},
+			Camera: "iphone 6",
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Updated photo: %#v\n", photo)
+}


### PR DESCRIPTION
Fixes #10.

Can now update a photo by using client method UpdatePhoto

Note that this method is a privileged one and requires
OAuth authorization for 500px to accept it, so initialize
the client with the OAuthClient as shown in the example below:

```go
func updatePhoto() {
	client, err := px500.NewOAuth1ClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	photo, err := client.UpdatePhoto(&px500.UpdateRequest{
		PhotoID: "211020335",
		Content: &px500.Photo{
			Title:  "Updated in tests",
			Tags:   []string{"tests", "api-client", "golang"},
			Camera: "iphone 6",
		},
	})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Updated photo: %#v\n", photo)
}
```