### PR TITLE
photos: implemented Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,19 @@ func updatePhoto() {
 	fmt.Printf("Updated photo: %#v\n", photo)
 }
 ```
+
+* Delete a photo 
+```go
+func deletePhoto() {
+	client, err := px500.NewOAuth1ClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := client.DeletePhoto("212664703"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Successfully deleted the photo!\n")
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -162,9 +162,9 @@ func Example_client_UploadPhoto() {
 
 	photo, err := client.UploadPhoto(&px500.UploadRequest{
 		Body:     f,
-		Filename: "billion dollar view",
+		Filename: "Testing delete",
 		PhotoInfo: &px500.Photo{
-			Title: "SF Panorama, Billion Dollar View",
+			Title: "Testing delete",
 			ISO:   "iPhone 6",
 			Tags:  []string{"sf", "bayBridge", "California", "Piers"},
 		},
@@ -216,4 +216,17 @@ func Example_client_UpdatePhoto() {
 	}
 
 	fmt.Printf("Updated photo: %#v\n", photo)
+}
+
+func Example_client_DeletePhoto() {
+	client, err := px500.NewOAuth1ClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := client.DeletePhoto("212664703"); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Successfully deleted the photo!\n")
 }

--- a/v1/photos.go
+++ b/v1/photos.go
@@ -480,6 +480,49 @@ func (c *Client) UpdatePhoto(ureq *UpdateRequest) (*Photo, error) {
 	return pwrap.Photo, nil
 }
 
+func (c *Client) DeletePhoto(photoID string) error {
+	photoID = strings.TrimSpace(photoID)
+	if photoID == "" {
+		return errEmptyPhotoID
+	}
+
+	fullURL := fmt.Sprintf("%s/photos/%s", baseURL, photoID)
+	req, err := http.NewRequest("DELETE", fullURL, nil)
+	if err != nil {
+		return err
+	}
+
+	slurp, _, err := c.doAuthAndRequest(req)
+	if err != nil {
+		return err
+	}
+
+	dres := new(deleteResponse)
+	if err := json.Unmarshal(slurp, dres); err != nil {
+		return err
+	}
+	if !otils.StatusOK(dres.Code_) {
+		return dres
+	}
+	return nil
+}
+
+type deleteResponse struct {
+	Message string `json:"message"`
+	Code_   int    `json:"status"`
+	Err     string `json:"error"`
+}
+
+var _ error = (*deleteResponse)(nil)
+
+func (dres *deleteResponse) Error() string {
+	return dres.Err
+}
+
+func (dres *deleteResponse) Code() int {
+	return dres.Code_
+}
+
 func writeStringFormField(mw *multipart.Writer, key, value string) {
 	if value != "" {
 		w, err := mw.CreateFormField(key)


### PR DESCRIPTION
Fixes #11.

Can now delete a photo by id

Note that this method is a privileged one and requires
OAuth authorization for 500px to accept it, so initialize
the client with the OAuthClient as shown in the example below:

```go
func deletePhoto() {
	client, err := px500.NewOAuth1ClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	if err := client.DeletePhoto("212664703"); err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Successfully deleted the photo!\n")
}
```